### PR TITLE
PageController ValueNotifier

### DIFF
--- a/lib/simple_coverflow.dart
+++ b/lib/simple_coverflow.dart
@@ -51,10 +51,10 @@ class CoverFlow extends StatefulWidget {
   /// ValueNotifier to interact with the PageController from outside.
   final ValueNotifier<PageController> controllerValueNotifier;
 
-  const CoverFlow({@required this.itemBuilder, this.dismissibleItems: true,
+  const CoverFlow({Key key, @required this.itemBuilder, this.dismissibleItems: true,
     this.dismissedCallback, this.viewportFraction: .85, this.height: 525,
     this.width: 700, this.itemCount: null, this.startIndex: null, this.currentItemChangedCallback: null, this.controllerValueNotifier})
-      : assert(itemBuilder != null);
+      : assert(itemBuilder != null), super(key: key);
 
   @override
   _CoverFlowState createState() => new _CoverFlowState();

--- a/lib/simple_coverflow.dart
+++ b/lib/simple_coverflow.dart
@@ -48,9 +48,12 @@ class CoverFlow extends StatefulWidget {
   /// Called when current item is changed.
   final OnCurrentItemChangedCallback currentItemChangedCallback;
 
+  /// ValueNotifier to interact with the PageController from outside.
+  final ValueNotifier<PageController> controllerValueNotifier;
+
   const CoverFlow({@required this.itemBuilder, this.dismissibleItems: true,
     this.dismissedCallback, this.viewportFraction: .85, this.height: 525,
-    this.width: 700, this.itemCount: null, this.startIndex: null, this.currentItemChangedCallback: null})
+    this.width: 700, this.itemCount: null, this.startIndex: null, this.currentItemChangedCallback: null, this.controllerValueNotifier})
       : assert(itemBuilder != null);
 
   @override
@@ -70,6 +73,9 @@ class _CoverFlowState extends State<CoverFlow> {
       viewportFraction: widget.viewportFraction,
       initialPage: currentPage,
     );
+    if (widget.controllerValueNotifier != null) {
+      widget.controllerValueNotifier.value = controller;
+    }
   }
 
   @override


### PR DESCRIPTION
I've added a ValueNotifier<PageController> to the Coverflow.
In this way outside widgets can interact with the PageController.
For example, I may want to go to next page when a button is clicked.

In a Scaffold I have a FAB
```
FloatingActionButton(
      child: Icon(Icons.lightbulb_outline),
      onPressed: () {
            this.pageControllerValueNotifier.value.nextPage(...)
      },
)
```

And then in the body the CoverFlow

```
CoverFlow(
      itemBuilder: (BuildContext context, int index) =>builder(context, index),
      controllerValueNotifier: this.pageControllerValueNotifier,
)
```